### PR TITLE
Fix ament_black for new get_sources API

### DIFF
--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -24,14 +24,13 @@ import time
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
-from black import get_sources
+from black import get_sources, find_project_root
 from black import main as black
 from black import re_compile_maybe_verbose
 from black.concurrency import maybe_install_uvloop
 from black.const import DEFAULT_EXCLUDES
 from black.const import DEFAULT_INCLUDES
 from black.report import Report
-import click
 from unidiff import PatchSet
 
 
@@ -79,7 +78,7 @@ def main(argv=sys.argv[1:]):
 
     # TODO(Nacho): Inject the config file results into the ctx (use read_pyproject_toml)
     sources = get_sources(
-        ctx=click.Context(black),
+        root=find_project_root(tuple(args.paths))[0],
         src=tuple(args.paths),
         quiet=True,
         verbose=False,

--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -25,7 +25,6 @@ import time
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
-from black import find_project_root
 from black import get_sources
 from black import main as black
 from black import re_compile_maybe_verbose
@@ -97,6 +96,7 @@ def main(argv=sys.argv[1:]):
             stdin_filename='',
         )
     else:
+        from black import find_project_root
         sources = get_sources(
             root=find_project_root(tuple(args.paths))[0],
             src=tuple(args.paths),

--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -24,7 +24,7 @@ import time
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
-from black import get_sources, find_project_root
+from black import find_project_root, get_sources
 from black import main as black
 from black import re_compile_maybe_verbose
 from black.concurrency import maybe_install_uvloop

--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -17,21 +17,22 @@
 
 import argparse
 import contextlib
+from importlib import metadata
 import os
 import sys
 import tempfile
 import time
 
 from packaging.version import Version
-from importlib import metadata
 
 BLACK_VERSION = metadata.version('black')
-BLACK_OLD_GET_SOURCES_API = Version(BLACK_VERSION) < Version("23.9.0")
+BLACK_OLD_GET_SOURCES_API = Version(BLACK_VERSION) < Version('23.9.0')
 
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
-from black import find_project_root, get_sources
+from black import find_project_root
+from black import get_sources
 from black import main as black
 from black import re_compile_maybe_verbose
 from black.concurrency import maybe_install_uvloop

--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -80,9 +80,8 @@ def main(argv=sys.argv[1:]):
         return 1
 
     # TODO(Nacho): Inject the config file results into the ctx (use read_pyproject_toml)
-    BLACK_VERSION = metadata.version('black')
-    BLACK_OLD_GET_SOURCES_API = Version(BLACK_VERSION) < Version('23.9.0')
-    if BLACK_OLD_GET_SOURCES_API:
+    BLACK_VERSION = Version(metadata.version('black'))
+    if BLACK_VERSION < Version('23.9.0'):
         sources = get_sources(
             ctx=click.Context(black),
             src=tuple(args.paths),
@@ -96,7 +95,10 @@ def main(argv=sys.argv[1:]):
             stdin_filename='',
         )
     else:
+        # Hack to support newer versions of black in ROS Jazzy
+        # https://github.com/botsandus/ament_black/issues/12
         from black import find_project_root
+
         sources = get_sources(
             root=find_project_root(tuple(args.paths))[0],
             src=tuple(args.paths),

--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -22,12 +22,6 @@ import os
 import sys
 import tempfile
 import time
-
-from packaging.version import Version
-
-BLACK_VERSION = metadata.version('black')
-BLACK_OLD_GET_SOURCES_API = Version(BLACK_VERSION) < Version('23.9.0')
-
 from xml.sax.saxutils import escape
 from xml.sax.saxutils import quoteattr
 
@@ -40,6 +34,7 @@ from black.const import DEFAULT_EXCLUDES
 from black.const import DEFAULT_INCLUDES
 from black.report import Report
 import click
+from packaging.version import Version
 from unidiff import PatchSet
 
 
@@ -86,6 +81,8 @@ def main(argv=sys.argv[1:]):
         return 1
 
     # TODO(Nacho): Inject the config file results into the ctx (use read_pyproject_toml)
+    BLACK_VERSION = metadata.version('black')
+    BLACK_OLD_GET_SOURCES_API = Version(BLACK_VERSION) < Version('23.9.0')
     if BLACK_OLD_GET_SOURCES_API:
         sources = get_sources(
             ctx=click.Context(black),
@@ -260,7 +257,6 @@ def get_xunit_content(report, testname, elapsed, checked_files):
 """
         % data
     )
-
     xml += '</testsuite>\n'
     return xml
 


### PR DESCRIPTION
This is my attempt to fix #12. Not sure if it is the correct way but it seems to work. Though, it will break support for black pre 23.9.0 version. Maybe we can do a version check. Any suggestions?