### PR TITLE
Add packaging as a required dependency

### DIFF
--- a/ament_black/setup.py
+++ b/ament_black/setup.py
@@ -13,6 +13,7 @@ setup(
     ],
     install_requires=[
         'black==21.12b0',
+        'packaging>=20.3',
         'setuptools>=56',
         'unidiff>=0.5',
         'uvloop==0.17.0',


### PR DESCRIPTION
This add a missing declared dependency for the [`packaging`](https://pypi.org/project/packaging) library, as a follow up to:
- https://github.com/botsandus/ament_black/pull/13

As can be seen in use here:

https://github.com/botsandus/ament_black/blob/81af88419ec46ea30a23a4278678ec3ea9335915/ament_black/ament_black/main.py#L36

As for the minimum version number, I simply opted to use whatever shipped with Ubuntu 20.04.

- https://packages.ubuntu.com/focal/python3-packaging

We could probable go further back, as it looks to have been around awhile:

- https://github.com/pypa/packaging/blame/c385b58c4d0e4d66f5c8273ebb155801c92aadf3/src/packaging/version.py#L161